### PR TITLE
Dashboard improvements, dedicated scan runs page, and started_at fix

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -95,6 +95,7 @@ func main() {
 			authorized.PUT("/scans/tasks/:id", handlers.UpdateScanTask)
 			authorized.DELETE("/scans/tasks/:id", handlers.DeleteScanTask)
 			authorized.POST("/scans/tasks/:id/run", handlers.RunScanTask(cfg))
+			authorized.GET("/scans/runs", handlers.ListScanRuns)
 			authorized.GET("/scans/runs/:id", handlers.GetScanRun)
 
 			authorized.POST("/schedules/tasks/:id/schedule", handlers.ScheduleTask)
@@ -125,6 +126,7 @@ func main() {
 	router.GET("/tasks/create", handlers.TaskCreatePage)
 	router.GET("/tasks/view/:id", handlers.TaskViewPage)
 	router.GET("/tasks/run/:id", handlers.TaskRunPage)
+	router.GET("/runs", handlers.ScanRunsPage)
 	router.GET("/reports", handlers.ReportsPage)
 	router.GET("/reports/:id", handlers.ReportViewPage)
 	router.GET("/admin/users", handlers.AdminUsersPage)

--- a/internal/handlers/pages.go
+++ b/internal/handlers/pages.go
@@ -108,6 +108,13 @@ func TaskRunPage(c *gin.Context) {
 	renderPage(c, "tasks/run", PageData{Title: "Live Scan"})
 }
 
+func ScanRunsPage(c *gin.Context) {
+	if !requireUser(c) {
+		return
+	}
+	renderPage(c, "runs/index", PageData{Title: "All Scan Runs"})
+}
+
 func ReportsPage(c *gin.Context) {
 	if !requireUser(c) {
 		return

--- a/internal/handlers/reports.go
+++ b/internal/handlers/reports.go
@@ -40,7 +40,8 @@ func GetReport(c *gin.Context) {
 	u := user.(models.User)
 
 	var report models.ScanReport
-	if err := db.DB.Preload("Hosts.Ports").Joins("JOIN scan_runs ON scan_runs.id = scan_reports.scan_run_id").
+	if err := db.DB.Preload("Hosts.Ports").Preload("ScanRun.Task").
+		Joins("JOIN scan_runs ON scan_runs.id = scan_reports.scan_run_id").
 		Joins("JOIN scan_tasks ON scan_tasks.id = scan_runs.task_id").
 		Where("scan_reports.id = ? AND scan_tasks.user_id = ?", id, u.ID).First(&report).Error; err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"detail": "Report not found"})

--- a/internal/handlers/scans.go
+++ b/internal/handlers/scans.go
@@ -218,3 +218,32 @@ func GetScanRun(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, run)
 }
+
+func ListScanRuns(c *gin.Context) {
+	user, _ := c.Get("user")
+	u := user.(models.User)
+	page, perPage := parsePagination(c)
+
+	status := c.Query("status")
+
+	query := db.DB.Model(&models.ScanRun{}).
+		Joins("JOIN scan_tasks ON scan_tasks.id = scan_runs.task_id").
+		Where("scan_tasks.user_id = ?", u.ID)
+	if status != "" {
+		query = query.Where("scan_runs.status = ?", status)
+	}
+
+	var total int64
+	query.Count(&total)
+
+	var runs []models.ScanRun
+	q := db.DB.Preload("Task").Preload("Report").
+		Joins("JOIN scan_tasks ON scan_tasks.id = scan_runs.task_id").
+		Where("scan_tasks.user_id = ?", u.ID)
+	if status != "" {
+		q = q.Where("scan_runs.status = ?", status)
+	}
+	q.Order("scan_runs.id DESC").Offset(offset(page, perPage)).Limit(perPage).Find(&runs)
+
+	c.JSON(http.StatusOK, paginatedResponse(runs, total, page, perPage))
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -76,6 +76,7 @@ type ScanRun struct {
 type ScanReport struct {
 	gorm.Model
 	ScanRunID        uint          `gorm:"not null;uniqueIndex"`
+	ScanRun          *ScanRun
 	Summary          string        `gorm:"type:text"`
 	XMLReportPath    string        `gorm:"size:255"`
 	NormalReportPath string        `gorm:"size:255"`

--- a/internal/services/nmap.go
+++ b/internal/services/nmap.go
@@ -90,9 +90,12 @@ func ExecuteScan(ctx context.Context, runID, taskID uint, cfg *config.Config) er
 	}
 
 	pid := cmd.Process.Pid
-	db.DB.Model(&models.ScanRun{}).Where("id = ?", runID).Updates(map[string]interface{}{
-		"status": "running", "started_at": time.Now(), "nmap_pid": pid,
-	})
+	now := time.Now()
+	if err := db.DB.Model(&models.ScanRun{}).Where("id = ?", runID).Updates(map[string]interface{}{
+		"status": "running", "started_at": now, "nmap_p_id": pid,
+	}).Error; err != nil {
+		fmt.Fprintf(os.Stderr, "[nmap] Run %d: failed to update started_at/pid: %v\n", runID, err)
+	}
 
 	publish(ctx, runID, "status", map[string]interface{}{
 		"status": "running", "pid": pid,

--- a/templates/main/index.html
+++ b/templates/main/index.html
@@ -39,10 +39,35 @@
     </div>
 </div>
 
+<!-- Active Scans Table (only shown when there are running/queued scans) -->
+<div id="activeScansSection" class="mb-8 hidden">
+    <div class="bg-gray-800 rounded-lg shadow overflow-hidden border border-amber-900/50">
+        <div class="px-6 py-4 border-b border-gray-700 flex items-center justify-between">
+            <h3 class="text-lg font-semibold"><i class="fas fa-bolt text-amber-400 mr-2"></i>Active Scans</h3>
+        </div>
+        <div class="overflow-x-auto">
+            <table class="w-full text-left">
+                <thead class="bg-gray-700 text-gray-300 text-sm uppercase">
+                    <tr>
+                        <th class="px-6 py-3">Run ID</th>
+                        <th class="px-6 py-3">Task</th>
+                        <th class="px-6 py-3">Status</th>
+                        <th class="px-6 py-3">Progress</th>
+                        <th class="px-6 py-3">Started</th>
+                        <th class="px-6 py-3"></th>
+                    </tr>
+                </thead>
+                <tbody id="activeScansBody" class="divide-y divide-gray-700"></tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+<!-- Recent Scan Runs -->
 <div class="bg-gray-800 rounded-lg shadow overflow-hidden">
     <div class="px-6 py-4 border-b border-gray-700 flex items-center justify-between">
         <h3 class="text-lg font-semibold">Recent Scan Runs</h3>
-        <a href="/tasks" class="text-emerald-400 text-sm hover:underline">View All</a>
+        <a href="/runs" class="text-emerald-400 text-sm hover:underline">View More &rarr;</a>
     </div>
     <div class="overflow-x-auto">
         <table class="w-full text-left">
@@ -72,23 +97,50 @@ async function loadDashboard() {
     const tasksData = await tasksRes.json();
     const tasks = tasksData.items || [];
     document.getElementById('totalTasks').textContent = tasksData.total || tasks.length;
-    document.getElementById('runningScans').textContent = tasks.filter(t =>
-        t.ScanRuns && t.ScanRuns.some(r => r.Status === 'running')
-    ).length;
+
+    // Collect all runs with task name
+    const allRuns = tasks.flatMap(t => (t.ScanRuns || []).map(r => ({...r, taskName: t.Name, taskId: t.ID})));
+    const activeRuns = allRuns.filter(r => r.Status === 'running' || r.Status === 'queued');
+
+    document.getElementById('runningScans').textContent = activeRuns.filter(r => r.Status === 'running').length;
+
     if (reportsRes.ok) {
         const reportsData = await reportsRes.json();
         document.getElementById('totalReports').textContent = reportsData.total || 0;
     }
-    // Recent runs from tasks
+
+    // Active scans table
+    const activeSection = document.getElementById('activeScansSection');
+    const activeBody = document.getElementById('activeScansBody');
+    if (activeRuns.length > 0) {
+        activeSection.classList.remove('hidden');
+        activeBody.innerHTML = activeRuns.sort((a,b) => (b.ID || 0) - (a.ID || 0)).map(r => `
+            <tr class="hover:bg-gray-700/30 transition-colors">
+                <td class="px-6 py-3 text-sm font-mono text-gray-400">${r.ID}</td>
+                <td class="px-6 py-3 text-sm"><a href="/tasks/view/${r.taskId}" class="text-emerald-400 hover:underline">${escapeHtml(r.taskName)}</a></td>
+                <td class="px-6 py-3 text-sm">${statusBadge(r.Status)}</td>
+                <td class="px-6 py-3 text-sm">
+                    <div class="w-full bg-gray-700 rounded-full h-2"><div class="bg-amber-500 h-2 rounded-full transition-all" style="width: ${r.Progress || 0}%"></div></div>
+                    <span class="text-xs text-gray-400">${r.Progress || 0}%</span>
+                </td>
+                <td class="px-6 py-3 text-sm text-gray-400">${r.StartedAt ? new Date(r.StartedAt).toLocaleString() : '-'}</td>
+                <td class="px-6 py-3 text-sm"><a href="/tasks/run/${r.ID}" class="inline-flex items-center text-amber-400 hover:text-amber-300 text-xs font-medium"><i class="fas fa-broadcast-tower mr-1"></i>Live</a></td>
+            </tr>
+        `).join('');
+    } else {
+        activeSection.classList.add('hidden');
+    }
+
+    // Recent runs (top 10)
+    const recentRuns = allRuns.sort((a,b) => (b.ID || 0) - (a.ID || 0)).slice(0, 10);
     const tbody = document.getElementById('recentRunsBody');
-    const allRuns = tasks.flatMap(t => (t.ScanRuns || []).map(r => ({...r, taskName: t.Name}))).sort((a,b) => (b.ID || 0) - (a.ID || 0)).slice(0, 5);
-    if (allRuns.length === 0) {
+    if (recentRuns.length === 0) {
         tbody.innerHTML = '<tr><td colspan="4" class="px-6 py-4 text-center text-gray-500">No runs yet</td></tr>';
         return;
     }
-    tbody.innerHTML = allRuns.map(r => `
-        <tr>
-            <td class="px-6 py-3 text-sm">${escapeHtml(r.taskName)}</td>
+    tbody.innerHTML = recentRuns.map(r => `
+        <tr class="hover:bg-gray-700/30 transition-colors">
+            <td class="px-6 py-3 text-sm"><a href="/tasks/view/${r.taskId}" class="text-emerald-400 hover:underline">${escapeHtml(r.taskName)}</a></td>
             <td class="px-6 py-3 text-sm">${statusBadge(r.Status)}</td>
             <td class="px-6 py-3 text-sm">
                 <div class="w-full bg-gray-700 rounded-full h-2"><div class="bg-emerald-500 h-2 rounded-full" style="width: ${r.Progress || 0}%"></div></div>

--- a/templates/reports/view.html
+++ b/templates/reports/view.html
@@ -8,6 +8,7 @@
     <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between mb-6 gap-4">
         <div>
             <h1 class="text-2xl font-bold">Scan Report <span id="reportId" class="text-emerald-400">#...</span></h1>
+            <p id="reportTask" class="text-sm mt-1 hidden"><span class="text-gray-400">Task:</span> <a id="reportTaskLink" href="#" class="text-emerald-400 hover:underline"></a></p>
             <p id="reportMeta" class="text-gray-400 text-sm mt-1"></p>
         </div>
         <div class="flex flex-wrap gap-2">
@@ -53,6 +54,15 @@ async function loadReport() {
     const report = await res.json();
     const hosts = report.Hosts || [];
     const container = document.getElementById('hostsContainer');
+
+    if (report.ScanRun && report.ScanRun.Task) {
+        const task = report.ScanRun.Task;
+        const taskEl = document.getElementById('reportTask');
+        const linkEl = document.getElementById('reportTaskLink');
+        linkEl.href = `/tasks/view/${task.ID}`;
+        linkEl.textContent = task.Name;
+        taskEl.classList.remove('hidden');
+    }
 
     if (report.CreatedAt) {
         document.getElementById('reportMeta').textContent = `Generated on ${new Date(report.CreatedAt).toLocaleString()}${report.Summary ? ' \u2022 ' + report.Summary : ''}`;

--- a/templates/runs/index.html
+++ b/templates/runs/index.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="en">
+{{template "head" .}}
+<body class="bg-gray-900 text-gray-100 min-h-screen">
+{{template "nav" .}}
+<main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+<div class="flex items-center justify-between mb-6">
+    <div>
+        <h1 class="text-2xl font-bold">All Scan Runs</h1>
+        <p class="text-gray-400 text-sm mt-1">History of all scan executions across tasks</p>
+    </div>
+    <div class="flex items-center gap-3">
+        <select id="statusFilter" onchange="filterChanged()" class="bg-gray-700 border border-gray-600 text-gray-300 text-xs rounded px-2 py-1 focus:ring-emerald-500 focus:border-emerald-500">
+            <option value="">All statuses</option>
+            <option value="running">Running</option>
+            <option value="queued">Queued</option>
+            <option value="completed">Completed</option>
+            <option value="failed">Failed</option>
+        </select>
+        <div class="flex items-center gap-1">
+            <span class="text-xs text-gray-500 mr-1">Per page:</span>
+            <button onclick="setPerPage(20)" data-pp="20" class="pp-btn px-2 py-0.5 rounded text-xs border border-emerald-500 bg-emerald-900 text-emerald-300">20</button>
+            <button onclick="setPerPage(50)" data-pp="50" class="pp-btn px-2 py-0.5 rounded text-xs border border-gray-600 bg-gray-700 text-gray-300 hover:bg-gray-600">50</button>
+            <button onclick="setPerPage(100)" data-pp="100" class="pp-btn px-2 py-0.5 rounded text-xs border border-gray-600 bg-gray-700 text-gray-300 hover:bg-gray-600">100</button>
+            <button onclick="setPerPage(500)" data-pp="500" class="pp-btn px-2 py-0.5 rounded text-xs border border-gray-600 bg-gray-700 text-gray-300 hover:bg-gray-600">500</button>
+        </div>
+    </div>
+</div>
+
+<div class="bg-gray-800 rounded-lg shadow overflow-hidden">
+    <div class="overflow-x-auto">
+        <table class="w-full text-left">
+            <thead class="bg-gray-700 text-gray-300 text-sm uppercase">
+                <tr>
+                    <th class="px-6 py-3">ID</th>
+                    <th class="px-6 py-3">Task</th>
+                    <th class="px-6 py-3">Status</th>
+                    <th class="px-6 py-3">Progress</th>
+                    <th class="px-6 py-3">Started</th>
+                    <th class="px-6 py-3">Completed</th>
+                    <th class="px-6 py-3">Report</th>
+                    <th class="px-6 py-3"></th>
+                </tr>
+            </thead>
+            <tbody id="runsBody" class="divide-y divide-gray-700">
+                <tr><td colspan="8" class="px-6 py-4 text-center text-gray-500">Loading...</td></tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<div id="paginationControls" class="hidden flex items-center justify-between mt-4">
+    <span class="text-sm text-gray-400" id="pageInfo"></span>
+    <div class="flex items-center gap-2">
+        <button onclick="goPage(currentPage-1)" id="prevBtn" class="px-3 py-1.5 rounded text-sm bg-gray-700 hover:bg-gray-600 text-gray-300 disabled:opacity-40 disabled:cursor-not-allowed transition">Prev</button>
+        <span class="text-sm text-gray-400" id="pageNums"></span>
+        <button onclick="goPage(currentPage+1)" id="nextBtn" class="px-3 py-1.5 rounded text-sm bg-gray-700 hover:bg-gray-600 text-gray-300 disabled:opacity-40 disabled:cursor-not-allowed transition">Next</button>
+    </div>
+</div>
+
+<script>
+let currentPage = 1;
+let perPage = 20;
+let totalPages = 1;
+
+function setPerPage(n) {
+    perPage = n;
+    currentPage = 1;
+    document.querySelectorAll('.pp-btn').forEach(b => {
+        const active = parseInt(b.dataset.pp) === n;
+        b.className = 'pp-btn px-2 py-0.5 rounded text-xs border ' + (active ? 'border-emerald-500 bg-emerald-900 text-emerald-300' : 'border-gray-600 bg-gray-700 text-gray-300 hover:bg-gray-600');
+    });
+    loadRuns();
+}
+function filterChanged() { currentPage = 1; loadRuns(); }
+function goPage(p) { if (p >= 1 && p <= totalPages) { currentPage = p; loadRuns(); } }
+
+function updatePagination(data) {
+    totalPages = data.pages;
+    const controls = document.getElementById('paginationControls');
+    if (data.total <= data.per_page && data.page === 1) { controls.classList.add('hidden'); return; }
+    controls.classList.remove('hidden');
+    const start = (data.page - 1) * data.per_page + 1;
+    const end = Math.min(data.page * data.per_page, data.total);
+    document.getElementById('pageInfo').textContent = `Showing ${start}-${end} of ${data.total}`;
+    document.getElementById('pageNums').textContent = `Page ${data.page} of ${data.pages}`;
+    document.getElementById('prevBtn').disabled = data.page <= 1;
+    document.getElementById('nextBtn').disabled = data.page >= data.pages;
+}
+
+function statusBadge(status) {
+    const colors = { queued: 'bg-gray-700 text-gray-300', running: 'bg-amber-900 text-amber-300', completed: 'bg-emerald-900 text-emerald-300', failed: 'bg-red-900 text-red-300' };
+    return `<span class="px-2 py-1 rounded text-xs font-medium ${colors[status] || colors.queued}">${status}</span>`;
+}
+function escapeHtml(text) { const div = document.createElement('div'); div.textContent = text; return div.innerHTML; }
+
+async function loadRuns() {
+    const status = document.getElementById('statusFilter').value;
+    let url = `/api/scans/runs?page=${currentPage}&per_page=${perPage}`;
+    if (status) url += `&status=${status}`;
+    const res = await fetch(url, { credentials: 'same-origin' });
+    if (!res.ok) { document.getElementById('runsBody').innerHTML = '<tr><td colspan="8" class="px-6 py-4 text-center text-red-400">Failed to load</td></tr>'; return; }
+    const data = await res.json();
+    const runs = data.items || [];
+    const tbody = document.getElementById('runsBody');
+    if (runs.length === 0 && data.total === 0) {
+        tbody.innerHTML = '<tr><td colspan="8" class="px-6 py-8 text-center text-gray-500">No scan runs found</td></tr>';
+        document.getElementById('paginationControls').classList.add('hidden');
+        return;
+    }
+    tbody.innerHTML = runs.map(r => {
+        const taskName = r.Task ? escapeHtml(r.Task.Name) : '-';
+        const taskId = r.Task ? r.Task.ID : r.TaskID;
+        const reportLink = r.Report ? `<a href="/reports/${r.Report.ID}" class="text-emerald-400 hover:underline text-xs">#${r.Report.ID}</a>` : '<span class="text-gray-500 text-xs">-</span>';
+        const liveLink = (r.Status === 'running' || r.Status === 'queued') ? `<a href="/tasks/run/${r.ID}" class="text-amber-400 hover:underline text-xs"><i class="fas fa-broadcast-tower mr-1"></i>Live</a>` : '';
+        return `<tr class="hover:bg-gray-700/30 transition-colors">
+            <td class="px-6 py-3 text-sm font-mono text-gray-400">${r.ID}</td>
+            <td class="px-6 py-3 text-sm"><a href="/tasks/view/${taskId}" class="text-emerald-400 hover:underline">${taskName}</a></td>
+            <td class="px-6 py-3 text-sm">${statusBadge(r.Status)}</td>
+            <td class="px-6 py-3 text-sm">
+                <div class="w-full bg-gray-700 rounded-full h-2"><div class="bg-emerald-500 h-2 rounded-full" style="width: ${r.Progress || 0}%"></div></div>
+                <span class="text-xs text-gray-400">${r.Progress || 0}%</span>
+            </td>
+            <td class="px-6 py-3 text-sm text-gray-400">${r.StartedAt ? new Date(r.StartedAt).toLocaleString() : '-'}</td>
+            <td class="px-6 py-3 text-sm text-gray-400">${r.CompletedAt ? new Date(r.CompletedAt).toLocaleString() : '-'}</td>
+            <td class="px-6 py-3 text-sm">${reportLink}</td>
+            <td class="px-6 py-3 text-sm">${liveLink}</td>
+        </tr>`;
+    }).join('');
+    updatePagination(data);
+}
+loadRuns();
+</script>
+</main>
+</body>
+</html>


### PR DESCRIPTION
1. Dashboard: increase recent scan runs from 5 to 10
   - Recent Scan Runs table now shows 10 entries instead of 5
   - "View All" link replaced with "View More" pointing to /runs
   - Task names in recent runs are clickable links to the task view

2. Dashboard: active scans table
   - New "Active Scans" section with amber border, shown only when there are running or queued scans, hidden otherwise
   - Displays Run ID, Task (clickable), Status, Progress, Started
   - Each row has a "Live" button linking to the real-time scan progress page at /tasks/run/:id
   - Auto-refreshes every 10 seconds along with the rest of the dashboard

3. New dedicated /runs page with pagination
   - New template at templates/runs/index.html
   - Lists all scan runs across all tasks for the current user
   - Columns: ID, Task (linked), Status, Progress, Started, Completed, Report (linked), Live button
   - Status filter dropdown (All/Running/Queued/Completed/Failed)
   - Per-page selector (20/50/100/500) with prev/next pagination
   - New API endpoint GET /api/scans/runs with optional status filter
   - New ListScanRuns handler in scans.go
   - New ScanRunsPage handler in pages.go
   - Route registered in main.go

4. Report view: show parent scan task
   - Report page now displays "Task: <task-name>" below the report ID, clickable to /tasks/view/:id
   - Added ScanRun relation field to ScanReport model so GORM can preload the chain ScanReport -> ScanRun -> ScanTask
   - GetReport handler now preloads ScanRun.Task

5. Fix started_at never being written to database
   - Root cause: nmap.go used "nmap_pid" as the map key in a GORM Updates() call, but the actual SQLite column is "nmap_p_id" (GORM auto-naming from the NmapPID struct field). This caused the entire UPDATE statement to fail, so started_at in the same update was also never written.
   - Fix: changed map key from "nmap_pid" to "nmap_p_id"
   - Added error logging for this update so failures are visible