### PR TITLE
Show last scan summary on /tasks page with open port count and top 10 ports

### DIFF
--- a/internal/handlers/scans.go
+++ b/internal/handlers/scans.go
@@ -23,6 +23,92 @@ type ScanTaskInput struct {
 	TargetGroupIDs      []uint    `json:"target_group_ids"`
 }
 
+// LastScanPortEntry represents a single open port entry in the last scan summary.
+type LastScanPortEntry struct {
+	IPAddress  string `json:"ip_address"`
+	PortNumber int    `json:"port_number"`
+	Protocol   string `json:"protocol"`
+	Service    string `json:"service"`
+	Version    string `json:"version"`
+}
+
+// LastScanSummary contains a brief summary of the most recent completed scan for a task.
+type LastScanSummary struct {
+	RunID       uint                `json:"run_id"`
+	ReportID    uint                `json:"report_id"`
+	TotalOpen   int                 `json:"total_open"`
+	TotalHosts  int                 `json:"total_hosts"`
+	TopPorts    []LastScanPortEntry `json:"top_ports"`
+}
+
+// ScanTaskWithSummary wraps ScanTask with an optional last scan summary.
+type ScanTaskWithSummary struct {
+	models.ScanTask
+	LastScanSummary *LastScanSummary `json:"last_scan_summary"`
+}
+
+func buildLastScanSummary(taskID uint) *LastScanSummary {
+	// Find the most recent completed scan run with a report for this task.
+	var run models.ScanRun
+	if err := db.DB.Preload("Report").
+		Where("task_id = ? AND status = 'completed'", taskID).
+		Order("id DESC").First(&run).Error; err != nil {
+		return nil
+	}
+	if run.Report == nil {
+		return nil
+	}
+
+	// Count total open ports across all hosts.
+	var totalOpen int64
+	db.DB.Model(&models.PortFinding{}).
+		Joins("JOIN host_findings ON host_findings.id = port_findings.host_id").
+		Where("host_findings.report_id = ? AND port_findings.state = 'open'", run.Report.ID).
+		Count(&totalOpen)
+
+	// Count total hosts.
+	var totalHosts int64
+	db.DB.Model(&models.HostFinding{}).
+		Where("report_id = ?", run.Report.ID).
+		Count(&totalHosts)
+
+	// Fetch up to 10 open ports with host info.
+	type rawPort struct {
+		IPAddress  string
+		PortNumber int
+		Protocol   string
+		Service    string
+		Version    string
+	}
+	var rawPorts []rawPort
+	db.DB.Model(&models.PortFinding{}).
+		Select("host_findings.ip_address, port_findings.port_number, port_findings.protocol, port_findings.service, port_findings.version").
+		Joins("JOIN host_findings ON host_findings.id = port_findings.host_id").
+		Where("host_findings.report_id = ? AND port_findings.state = 'open'", run.Report.ID).
+		Order("host_findings.ip_address ASC, port_findings.port_number ASC").
+		Limit(10).
+		Scan(&rawPorts)
+
+	topPorts := make([]LastScanPortEntry, len(rawPorts))
+	for i, p := range rawPorts {
+		topPorts[i] = LastScanPortEntry{
+			IPAddress:  p.IPAddress,
+			PortNumber: p.PortNumber,
+			Protocol:   p.Protocol,
+			Service:    p.Service,
+			Version:    p.Version,
+		}
+	}
+
+	return &LastScanSummary{
+		RunID:      run.ID,
+		ReportID:   run.Report.ID,
+		TotalOpen:  int(totalOpen),
+		TotalHosts: int(totalHosts),
+		TopPorts:   topPorts,
+	}
+}
+
 func ListScanProfiles(c *gin.Context) {
 	var profiles []gin.H
 	for k, v := range config.DefaultProfiles {
@@ -43,7 +129,16 @@ func ListScanTasks(c *gin.Context) {
 	db.DB.Preload("TargetGroups").Preload("ScanRuns").Where("user_id = ?", u.ID).
 		Order("id DESC").Offset(offset(page, perPage)).Limit(perPage).Find(&tasks)
 
-	c.JSON(http.StatusOK, paginatedResponse(tasks, total, page, perPage))
+	// Enrich each task with its last scan summary.
+	enriched := make([]ScanTaskWithSummary, len(tasks))
+	for i, t := range tasks {
+		enriched[i] = ScanTaskWithSummary{
+			ScanTask:        t,
+			LastScanSummary: buildLastScanSummary(t.ID),
+		}
+	}
+
+	c.JSON(http.StatusOK, paginatedResponse(enriched, total, page, perPage))
 }
 
 func CreateScanTask(c *gin.Context) {

--- a/templates/tasks/index.html
+++ b/templates/tasks/index.html
@@ -70,19 +70,56 @@ async function loadTasks() {
         document.getElementById('paginationControls').classList.add('hidden');
         return;
     }
-    container.innerHTML = tasks.map(t => `
-        <div class="bg-gray-800 rounded-lg p-4 flex items-center justify-between shadow hover:shadow-lg transition">
-            <div>
-                <h3 class="font-semibold text-lg">${escapeHtml(t.Name)}</h3>
-                <p class="text-sm text-gray-400">${t.ScanProfile || 'Custom'} &bull; ${(t.TargetGroups || []).length} target groups</p>
-                ${t.IsScheduled ? '<span class="text-xs bg-blue-900 text-blue-300 px-2 py-0.5 rounded mt-1 inline-block">Scheduled</span>' : ''}
+    container.innerHTML = tasks.map(t => {
+        const s = t.last_scan_summary;
+        let summaryHtml = '';
+        if (s) {
+            const portRows = (s.top_ports || []).map(p =>
+                `<tr class="border-t border-gray-700">
+                    <td class="py-1 pr-3 font-mono text-xs text-gray-200">${escapeHtml(p.ip_address)}</td>
+                    <td class="py-1 pr-3 font-mono text-xs text-emerald-300">${p.port_number}/${escapeHtml(p.protocol)}</td>
+                    <td class="py-1 pr-3 text-xs text-blue-300">${escapeHtml(p.service || '-')}</td>
+                    <td class="py-1 text-xs text-gray-400">${escapeHtml(p.version || '-')}</td>
+                </tr>`
+            ).join('');
+            const moreBadge = s.total_open > 10
+                ? `<span class="ml-2 text-xs text-gray-500">+${s.total_open - 10} more</span>`
+                : '';
+            summaryHtml = `
+            <div class="mt-3 border border-gray-700 rounded-md bg-gray-900 px-3 pt-2 pb-2">
+                <div class="flex items-center gap-4 mb-2">
+                    <span class="text-xs text-gray-400">Last scan:</span>
+                    <span class="text-xs font-medium text-emerald-400"><i class="fas fa-plug mr-1"></i>${s.total_open} open port${s.total_open !== 1 ? 's' : ''}</span>
+                    <span class="text-xs text-gray-400">${s.total_hosts} host${s.total_hosts !== 1 ? 's' : ''}</span>
+                    <a href="/reports/${s.report_id}" class="text-xs text-blue-400 hover:underline ml-auto">View Report #${s.report_id}</a>
+                </div>
+                ${portRows ? `<table class="w-full">
+                    <thead><tr>
+                        <th class="text-left text-xs text-gray-500 font-semibold pb-1 pr-3">IP</th>
+                        <th class="text-left text-xs text-gray-500 font-semibold pb-1 pr-3">Port</th>
+                        <th class="text-left text-xs text-gray-500 font-semibold pb-1 pr-3">Service</th>
+                        <th class="text-left text-xs text-gray-500 font-semibold pb-1">Version</th>
+                    </tr></thead>
+                    <tbody>${portRows}</tbody>
+                </table>${moreBadge}` : '<span class="text-xs text-gray-500">No open ports found.</span>'}
+            </div>`;
+        }
+        return `
+        <div class="bg-gray-800 rounded-lg p-4 shadow hover:shadow-lg transition">
+            <div class="flex items-center justify-between">
+                <div>
+                    <h3 class="font-semibold text-lg">${escapeHtml(t.Name)}</h3>
+                    <p class="text-sm text-gray-400">${t.ScanProfile || 'Custom'} &bull; ${(t.TargetGroups || []).length} target groups</p>
+                    ${t.IsScheduled ? '<span class="text-xs bg-blue-900 text-blue-300 px-2 py-0.5 rounded mt-1 inline-block">Scheduled</span>' : ''}
+                </div>
+                <div class="flex items-center space-x-2">
+                    <button onclick="runTask(${t.ID})" class="bg-emerald-600 hover:bg-emerald-700 text-white px-3 py-1.5 rounded text-sm transition"><i class="fas fa-play mr-1"></i>Run</button>
+                    <a href="/tasks/view/${t.ID}" class="bg-gray-700 hover:bg-gray-600 text-white px-3 py-1.5 rounded text-sm transition">View</a>
+                </div>
             </div>
-            <div class="flex items-center space-x-2">
-                <button onclick="runTask(${t.ID})" class="bg-emerald-600 hover:bg-emerald-700 text-white px-3 py-1.5 rounded text-sm transition"><i class="fas fa-play mr-1"></i>Run</button>
-                <a href="/tasks/view/${t.ID}" class="bg-gray-700 hover:bg-gray-600 text-white px-3 py-1.5 rounded text-sm transition">View</a>
-            </div>
-        </div>
-    `).join('');
+            ${summaryHtml}
+        </div>`;
+    }).join('');
     updatePagination(data);
 }
 async function runTask(id) {


### PR DESCRIPTION
Each task card on the /tasks list now shows a collapsible summary of the most recent completed scan: total open ports, host count, and a table of up to 10 open ports (IP, port/protocol, service, version) with a link to the full report.

Backend: enriched ListScanTasks response with LastScanSummary struct built via buildLastScanSummary() - queries most recent completed run, counts open ports and hosts, fetches top 10 open ports ordered by IP + port number.